### PR TITLE
Typos in push-to-deploy.md

### DIFF
--- a/push-to-deploy.md
+++ b/push-to-deploy.md
@@ -23,7 +23,7 @@ In order to set up a webhook, navigate to the settings page of your GitLab repos
 
 ## 301 troubleshooting
 
-If nothing happens when you push to GitHub and you see nothing in the WP Pusher log, you most probably have a redirect problem. If you use GitHub, you can check the response from the webhook. If this is a 301 redirect response, WordPress and WP Pusher never got the webhook payload from GitHub (or Bitbucket or GitLab). This problem is caused when WordPress and your webserver is configured differently. Most probably, one has a trailing backslash and the other hasn't. WP Pusher uses WordPress' `site_url` to generate the Push-to-Deploy URL, so if this does not include a trailing backslash when the server is configured to add one, this will cause a redirect. GitHub (or Bitbucket or GitLab) will not follow a redirect, so neither WordPress nor WP Pusher will know anything about the webhook and nothing will be updated.
+If nothing happens when you push to GitHub and you see nothing in the WP Pusher log, you most probably have a redirect problem. If you use GitHub, you can check the response from the webhook. If this is a 301 redirect response, WordPress and WP Pusher never got the webhook payload from GitHub (or Bitbucket or GitLab). This problem is caused when WordPress and your webserver is configured differently. Most probably, one has a trailing slash and the other hasn't. WP Pusher uses WordPress' `site_url` to generate the Push-to-Deploy URL, so if this does not include a trailing slash when the server is configured to add one, this will cause a redirect. GitHub (or Bitbucket or GitLab) will not follow a redirect, so neither WordPress nor WP Pusher will know anything about the webhook and nothing will be updated.
 
 Let's say you have entered the following Push-to-Deploy URL and see a 301 redirect response:
 
@@ -31,7 +31,7 @@ Let's say you have entered the following Push-to-Deploy URL and see a 301 redire
 http://blog.wppusher.com?wppusher-hook&token=12345678
 ```
 
-Adding a backslash will solve the issue in most cases:
+Adding a slash will solve the issue in most cases:
 
 ```
 http://blog.wppusher.com/?wppusher-hook&token=12345678


### PR DESCRIPTION
The doc says "backslash" but it apparently should say "slash"
